### PR TITLE
Dev

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,7 @@ dependencies = [
     "numba>=0.56.0",
     "pyfftw>=0.12.0",
     "resampy>=0.4.3",
-    "scikit-learn>=1.6.1",
+    "scikit-image>=0.19.0",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
fix: scikit-image を依存関係に追加（skimage ModuleNotFoundError の修正）